### PR TITLE
Add explicit empty permissions to integration test token workflow

### DIFF
--- a/.github/workflows/resolve-integration-test-token.yml
+++ b/.github/workflows/resolve-integration-test-token.yml
@@ -25,6 +25,8 @@ on:
       app_private_key:
         required: false
 
+permissions: {}
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add explicit `permissions: {}` to `resolve-integration-test-token.yml`
- satisfy CodeQL guidance for workflows that do not require `GITHUB_TOKEN` permissions
- keep the change intentionally minimal and behavior-preserving

## Validation
- validated the workflow YAML locally
- kept the PR scoped to a single workflow file
