### PR TITLE
feat: enhance authentication options in collect-linked-context workfl…

### DIFF
--- a/.github/workflows/collect-linked-context.yml
+++ b/.github/workflows/collect-linked-context.yml
@@ -7,6 +7,28 @@ on:
         description: Text to scan for GitHub links (e.g. PR body)
         required: true
         type: string
+      auth_mode:
+        description: Auth mode used to resolve a token when token is not provided directly (pat or app)
+        required: false
+        default: pat
+        type: string
+      installation_owner:
+        description: Installation owner used to mint a GitHub App token when auth_mode=app
+        required: false
+        type: string
+    secrets:
+      token:
+        description: Direct token override; takes precedence over auth_mode resolution
+        required: false
+      pat_token:
+        description: PAT used when auth_mode=pat
+        required: false
+      app_id:
+        description: GitHub App ID used when auth_mode=app
+        required: false
+      app_private_key:
+        description: GitHub App private key used when auth_mode=app
+        required: false
     outputs:
       value:
         description: Formatted linked context text, or empty string if nothing found
@@ -23,13 +45,98 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       value: ${{ steps.collect.outputs.value }}
+    env:
+      AUTH_MODE: ${{ inputs.auth_mode }}
+      INSTALLATION_OWNER: ${{ inputs.installation_owner }}
+      DIRECT_TOKEN: ${{ secrets.token }}
+      PAT_TOKEN: ${{ secrets.pat_token }}
+      APP_ID: ${{ secrets.app_id }}
+      APP_PRIVATE_KEY: ${{ secrets.app_private_key }}
     steps:
+      - name: Validate workflow auth configuration
+        shell: bash
+        run: |
+          if [ -n "$DIRECT_TOKEN" ]; then
+            exit 0
+          fi
+
+          case "$AUTH_MODE" in
+            pat)
+              if [ -z "$PAT_TOKEN" ]; then
+                echo "pat_token secret is required when auth_mode=pat and token is not provided" >&2
+                exit 1
+              fi
+              ;;
+            app)
+              if [ -z "$APP_ID" ] || [ -z "$APP_PRIVATE_KEY" ] || [ -z "$INSTALLATION_OWNER" ]; then
+                echo "app_id, app_private_key, and installation_owner are required when auth_mode=app and token is not provided" >&2
+                exit 1
+              fi
+              ;;
+            *)
+              echo "Unsupported auth_mode: $AUTH_MODE" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Normalize GitHub App private key
+        if: ${{ env.DIRECT_TOKEN == '' && env.AUTH_MODE == 'app' }}
+        id: normalize-key
+        shell: bash
+        run: |
+          if [[ "$APP_PRIVATE_KEY" == *'\n'* ]]; then
+            printf 'private_key<<EOF\n%b\nEOF\n' "$APP_PRIVATE_KEY" >> "$GITHUB_OUTPUT"
+          else
+            printf 'private_key<<EOF\n%s\nEOF\n' "$APP_PRIVATE_KEY" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub App installation token
+        if: ${{ env.DIRECT_TOKEN == '' && env.AUTH_MODE == 'app' }}
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.app_id }}
+          private-key: ${{ steps.normalize-key.outputs.private_key }}
+          owner: ${{ inputs.installation_owner }}
+          skip-token-revoke: true
+
+      - name: Resolve workflow auth token
+        id: auth
+        shell: bash
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if [ -n "$DIRECT_TOKEN" ]; then
+            TOKEN="$DIRECT_TOKEN"
+          else
+            case "$AUTH_MODE" in
+              pat)
+                TOKEN="$PAT_TOKEN"
+                ;;
+              app)
+                TOKEN="$APP_TOKEN"
+                ;;
+              *)
+                echo "Unsupported auth_mode: $AUTH_MODE" >&2
+                exit 1
+                ;;
+            esac
+          fi
+
+          if [ -z "$TOKEN" ]; then
+            echo "Resolved token is empty" >&2
+            exit 1
+          fi
+
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+
       - name: Collect linked context
         id: collect
         uses: actions/github-script@v8
         env:
           INPUT_TEXT: ${{ inputs.text }}
         with:
+          github-token: ${{ steps.auth.outputs.token }}
           script: |
             const MAX_ITEMS = 5;
             const MAX_BODY_CHARS = 800;

--- a/.github/workflows/test-collect-linked-context.yml
+++ b/.github/workflows/test-collect-linked-context.yml
@@ -2,6 +2,15 @@ name: Test collect-linked-context
 
 on:
   workflow_dispatch:
+    inputs:
+      auth_mode:
+        description: Token source to use for cross-org auth tests (pat=ORG_PROJECT_TOKEN, app=GitHub App)
+        required: false
+        default: pat
+        type: choice
+        options:
+          - pat
+          - app
   pull_request:
     paths:
       - '.github/workflows/collect-linked-context.yml'
@@ -20,6 +29,9 @@ jobs:
     uses: ./.github/workflows/collect-linked-context.yml
     with:
       text: 'No links here, just plain text.'
+      auth_mode: pat
+    secrets:
+      pat_token: ${{ secrets.ORG_PROJECT_TOKEN }}
 
   assert-empty:
     name: '[1] Assert — output is empty for link-free text'
@@ -45,6 +57,9 @@ jobs:
     uses: ./.github/workflows/collect-linked-context.yml
     with:
       text: 'Фикс для #84 в этом репо.'
+      auth_mode: pat
+    secrets:
+      pat_token: ${{ secrets.ORG_PROJECT_TOKEN }}
 
   assert-short-ref:
     name: '[2] Assert — short ref resolves'
@@ -77,6 +92,12 @@ jobs:
     uses: ./.github/workflows/collect-linked-context.yml
     with:
       text: |
+        See https://github.com/ViRGiL175/github-productivity-utilities/pull/84
+        and same via Dependabot redirect:
+        https://redirect.github.com/ViRGiL175/github-productivity-utilities/pull/84
+      auth_mode: pat
+    secrets:
+      pat_token: ${{ secrets.ORG_PROJECT_TOKEN }}
         See https://github.com/ViRGiL175/github-productivity-utilities/pull/84
         and same via Dependabot redirect:
         https://redirect.github.com/ViRGiL175/github-productivity-utilities/pull/84
@@ -114,6 +135,11 @@ jobs:
       text: |
         Bumps actions/checkout from 3 to 4.
         Release notes: https://github.com/actions/checkout/releases/tag/v4.0.0
+      auth_mode: pat
+    secrets:
+      pat_token: ${{ secrets.ORG_PROJECT_TOKEN }}
+        Bumps actions/checkout from 3 to 4.
+        Release notes: https://github.com/actions/checkout/releases/tag/v4.0.0
 
   assert-release:
     name: '[4] Assert — release context fetched'
@@ -146,6 +172,9 @@ jobs:
     uses: ./.github/workflows/collect-linked-context.yml
     with:
       text: 'Original tracking issue: https://github.com/microsoft/vscode/issues/1'
+      auth_mode: pat
+    secrets:
+      pat_token: ${{ secrets.ORG_PROJECT_TOKEN }}
 
   assert-stable-issue:
     name: '[5] Assert — issue title appears in output'
@@ -179,6 +208,9 @@ jobs:
     uses: ./.github/workflows/collect-linked-context.yml
     with:
       text: 'Uses https://github.com/actions/checkout/pull/1 as reference.'
+      auth_mode: pat
+    secrets:
+      pat_token: ${{ secrets.ORG_PROJECT_TOKEN }}
 
   assert-stable-pr:
     name: '[6] Assert — PR/issue content fetched for actions/checkout#1'
@@ -212,6 +244,9 @@ jobs:
     uses: ./.github/workflows/collect-linked-context.yml
     with:
       text: 'Historic: https://github.com/torvalds/linux/commit/1da177e4c3f41524e886b7f1b8a0c1fc7321cac'
+      auth_mode: pat
+    secrets:
+      pat_token: ${{ secrets.ORG_PROJECT_TOKEN }}
 
   assert-stable-commit:
     name: '[7] Assert — commit message fetched'
@@ -235,3 +270,77 @@ jobs:
             exit 1
           fi
           echo "OK: 'Linux-2.6.12-rc2' found in output"
+
+  # ─── Case 8: cross-org private issue via PAT ─────────────────────────────
+  # ViRGiL-GH-Productivity/scrum-test-backlog#1 is a known private sandbox issue.
+  # GITHUB_TOKEN alone can't access it — requires ORG_PROJECT_TOKEN with cross-org scope.
+  collect-cross-org-pat:
+    name: '[8] Collect — cross-org private issue via PAT (auth_mode=pat)'
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    uses: ./.github/workflows/collect-linked-context.yml
+    with:
+      text: 'Backlog: ViRGiL-GH-Productivity/scrum-test-backlog#1'
+      auth_mode: pat
+    secrets:
+      pat_token: ${{ secrets.ORG_PROJECT_TOKEN }}
+
+  assert-cross-org-pat:
+    name: '[8] Assert — cross-org issue fetched via PAT'
+    runs-on: ubuntu-latest
+    needs: collect-cross-org-pat
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    env:
+      ACTUAL: ${{ needs.collect-cross-org-pat.outputs.value }}
+    steps:
+      - name: Output must not be empty
+        run: |
+          if [ -z "$ACTUAL" ]; then
+            echo "Expected issue context for scrum-test-backlog#1, got empty — PAT cross-org access failed" >&2
+            exit 1
+          fi
+          echo "OK: output not empty"
+      - name: Output must mention the issue number
+        run: |
+          if ! echo "$ACTUAL" | grep -q 'scrum-test-backlog#1'; then
+            echo "Expected 'scrum-test-backlog#1' in output, got: $ACTUAL" >&2
+            exit 1
+          fi
+          echo "OK: 'scrum-test-backlog#1' found in output"
+
+  # ─── Case 9: cross-org private issue via GitHub App ──────────────────────
+  # Same private issue, but token is minted from GitHub App credentials.
+  # Only runs on workflow_dispatch with auth_mode=app; skipped on pull_request and pat dispatch.
+  collect-cross-org-app:
+    name: '[9] Collect — cross-org private issue via App (auth_mode=app)'
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.auth_mode == 'app' }}
+    uses: ./.github/workflows/collect-linked-context.yml
+    with:
+      text: 'Backlog: ViRGiL-GH-Productivity/scrum-test-backlog#1'
+      auth_mode: app
+      installation_owner: ViRGiL-GH-Productivity
+    secrets:
+      app_id: ${{ secrets.ORG_AUTOMATION_APP_ID }}
+      app_private_key: ${{ secrets.ORG_AUTOMATION_APP_PRIVATE_KEY }}
+
+  assert-cross-org-app:
+    name: '[9] Assert — cross-org issue fetched via App'
+    runs-on: ubuntu-latest
+    needs: collect-cross-org-app
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.auth_mode == 'app' }}
+    env:
+      ACTUAL: ${{ needs.collect-cross-org-app.outputs.value }}
+    steps:
+      - name: Output must not be empty
+        run: |
+          if [ -z "$ACTUAL" ]; then
+            echo "Expected issue context for scrum-test-backlog#1, got empty — App cross-org access failed" >&2
+            exit 1
+          fi
+          echo "OK: output not empty"
+      - name: Output must mention the issue number
+        run: |
+          if ! echo "$ACTUAL" | grep -q 'scrum-test-backlog#1'; then
+            echo "Expected 'scrum-test-backlog#1' in output, got: $ACTUAL" >&2
+            exit 1
+          fi
+          echo "OK: 'scrum-test-backlog#1' found in output"

--- a/scripts/run-act-test.js
+++ b/scripts/run-act-test.js
@@ -39,7 +39,7 @@ const workflowEntries = [
   {
     name: 'test-collect-linked-context.yml',
     path: '.github/workflows/test-collect-linked-context.yml',
-    secrets: [],
+    secrets: ['ORG_PROJECT_TOKEN', 'ORG_AUTOMATION_APP_ID', 'ORG_AUTOMATION_APP_PRIVATE_KEY'],
   },
 ];
 


### PR DESCRIPTION
This pull request enhances the `collect-linked-context` workflow to support more flexible authentication options, enabling both Personal Access Token (PAT) and GitHub App-based authentication. It also extends the test workflow to cover cross-organization access scenarios, including private repositories, using both PAT and GitHub App tokens. The most significant changes are grouped below.

**Authentication flexibility and validation:**

* Added new input parameters (`auth_mode`, `installation_owner`) and secrets (`pat_token`, `app_id`, `app_private_key`) to `.github/workflows/collect-linked-context.yml`, allowing the workflow to resolve authentication either from a PAT or a GitHub App, with validation logic to ensure required credentials are provided for each mode. [[1]](diffhunk://#diff-da764298a4cd1f80315eb1eec847eed200108da75b091445c41d3d10b19d6ac0R10-R31) [[2]](diffhunk://#diff-da764298a4cd1f80315eb1eec847eed200108da75b091445c41d3d10b19d6ac0R48-R139)
* Implemented logic to normalize GitHub App private keys and mint installation tokens using the `actions/create-github-app-token` action, supporting seamless switching between PAT and App authentication.

**Test coverage for cross-org and private access:**

* Extended `.github/workflows/test-collect-linked-context.yml` to accept an `auth_mode` input, and parameterized all test cases to explicitly use `auth_mode: pat` with the appropriate secret. [[1]](diffhunk://#diff-80eee6a3903f8dbbcb53f50718760826edcdc6add6e66fa752d9bbaf13f36a59R5-R13) [[2]](diffhunk://#diff-80eee6a3903f8dbbcb53f50718760826edcdc6add6e66fa752d9bbaf13f36a59R32-R34) [[3]](diffhunk://#diff-80eee6a3903f8dbbcb53f50718760826edcdc6add6e66fa752d9bbaf13f36a59R60-R62) [[4]](diffhunk://#diff-80eee6a3903f8dbbcb53f50718760826edcdc6add6e66fa752d9bbaf13f36a59R98-R103) [[5]](diffhunk://#diff-80eee6a3903f8dbbcb53f50718760826edcdc6add6e66fa752d9bbaf13f36a59R138-R142) [[6]](diffhunk://#diff-80eee6a3903f8dbbcb53f50718760826edcdc6add6e66fa752d9bbaf13f36a59R175-R177) [[7]](diffhunk://#diff-80eee6a3903f8dbbcb53f50718760826edcdc6add6e66fa752d9bbaf13f36a59R211-R213) [[8]](diffhunk://#diff-80eee6a3903f8dbbcb53f50718760826edcdc6add6e66fa752d9bbaf13f36a59R247-R249)
* Added two new test cases for cross-organization access to a private issue: one using a PAT and another using a GitHub App, with assertions to verify that the issue context is fetched correctly in both scenarios.

**Test runner updates:**

* Updated `scripts/run-act-test.js` to include all necessary secrets (`ORG_PROJECT_TOKEN`, `ORG_AUTOMATION_APP_ID`, `ORG_AUTOMATION_APP_PRIVATE_KEY`) for running the enhanced test workflow locally.